### PR TITLE
Added articles right under video's

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -17,6 +17,11 @@
             <a href="https://www.youtube.com/watch?v=MWNcItWuKpI" class="button">TakeOff</a>
             <a href="https://www.youtube.com/watch?v=s6xrnYae1FU" class="button">Laracon</a>
         </div>
+
+        <div class="video-links">
+            ARTICLES:
+            <a href="http://blog.wyrihaximus.net/categories/reactphp-series/" class="button">WyriHaximus' series</a>
+        </div>
 </div>
 
 <div id="quotes" class="clearfix">


### PR DESCRIPTION
After a chat on IRC we came to the conclusion that it might be a good idea to put links to articles on the website and wiki. So this PR adds my own series about ReactPHP. For the wiki I've started adding articles here: https://github.com/reactphp/react/wiki/Articles

My intention is not to just add my own series to the front but atleast one or two others. So that we have a balanced set of links. Still in the processes of collecting more posts and adding them to the wiki. Suggestions are more them welcome :+1: 
