### PR TITLE
Implement changelog atom feeds

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -88,6 +88,42 @@ if ($input->hasParameterOption('--dev-server')) {
 }
 
 (new Symfony\Component\Filesystem\Filesystem())->remove($buildDir);
+(new Symfony\Component\Filesystem\Filesystem())->mkdir($buildDir);
+
+(function (Symfony\Component\Console\Output\OutputInterface $output, string $buildDir, array $components): void {
+    $output->write('Generating changelog.atom...');
+
+    $feed = new Zend\Feed\Writer\Feed();
+
+    $feed->setId(getenv('DEPLOY_URL') . '/changelog.html');
+    $feed->setLink(getenv('DEPLOY_URL') . '/changelog.html');
+    $feed->setFeedLink(getenv('DEPLOY_URL') . '/changelog.atom', 'atom');
+
+    $feed->setLanguage('en');
+    $feed->setTitle('Changelog');
+    $feed->setDateModified(time());
+
+    $releases = array_slice(React\Website\Data\releases($components), 0, 10);
+
+    foreach ($releases as $release) {
+        $entry = $feed->createEntry();
+
+        $entry->setTitle($release['component'] . ' ' . $release['version']);
+        $entry->setLink($release['url']);
+        $entry->setDateModified((int) $release['date']->format('U'));
+        $entry->setDescription($release['html']);
+        $entry->addAuthor($release['author']);
+
+        $feed->addEntry($entry);
+    }
+
+    file_put_contents(
+        $buildDir . '/changelog.atom',
+        $feed->export('atom')
+    );
+
+    $output->writeln('<info>Done</info>');
+})($output, $buildDir, $container['data.components']);
 
 call_user_func(
     $container['generator'],

--- a/bin/build
+++ b/bin/build
@@ -93,6 +93,8 @@ if ($input->hasParameterOption('--dev-server')) {
 (function (Symfony\Component\Console\Output\OutputInterface $output, string $buildDir, array $components): void {
     $output->write('Generating changelog.atom...');
 
+    $releases = array_slice(React\Website\Data\releases($components), 0, 10);
+
     $feed = new Zend\Feed\Writer\Feed();
 
     $feed->setId(getenv('DEPLOY_URL') . '/changelog.html');
@@ -101,9 +103,7 @@ if ($input->hasParameterOption('--dev-server')) {
 
     $feed->setLanguage('en');
     $feed->setTitle('Changelog');
-    $feed->setDateModified(time());
-
-    $releases = array_slice(React\Website\Data\releases($components), 0, 10);
+    $feed->setDateModified((int) $releases[0]['date']->format('U'));
 
     foreach ($releases as $release) {
         $entry = $feed->createEntry();

--- a/bin/build
+++ b/bin/build
@@ -102,7 +102,7 @@ if ($input->hasParameterOption('--dev-server')) {
     $feed->setFeedLink(getenv('DEPLOY_URL') . '/changelog.atom', 'atom');
 
     $feed->setLanguage('en');
-    $feed->setTitle('Changelog');
+    $feed->setTitle('The combined changelog for all ReactPHP components.');
     $feed->setDateModified((int) $releases[0]['date']->format('U'));
 
     foreach ($releases as $release) {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/filesystem": "^3.2",
         "symfony/process": "^3.2",
         "vlucas/phpdotenv": "^2.4",
-        "elvanto/litemoji": "^1.0"
+        "elvanto/litemoji": "^1.0",
+        "zendframework/zend-feed": "^2.10"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f147ac45c582ae1bfc28df7cc20f11ed",
+    "content-hash": "c0bd5d31a57025a3d626ba23b5b37d20",
     "packages": [],
     "packages-dev": [
         {
@@ -2312,6 +2312,158 @@
                 "environment"
             ],
             "time": "2016-09-01T10:05:43+00:00"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "31d8aafae982f9568287cb4dce987e6aff8fd074"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/31d8aafae982f9568287cb4dce987e6aff8fd074",
+                "reference": "31d8aafae982f9568287cb4dce987e6aff8fd074",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "keywords": [
+                "ZendFramework",
+                "escaper",
+                "zf"
+            ],
+            "time": "2018-04-25T15:48:53+00:00"
+        },
+        {
+            "name": "zendframework/zend-feed",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-feed.git",
+                "reference": "2815c29a4c4e52bf4033128592ea310b0f4e9379"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-feed/zipball/2815c29a4c4e52bf4033128592ea310b0f4e9379",
+                "reference": "2815c29a4c4e52bf4033128592ea310b0f4e9379",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-escaper": "^2.5.2",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "psr/http-message": "^1.0.1",
+                "zendframework/zend-cache": "^2.7.2",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-db": "^2.8.2",
+                "zendframework/zend-http": "^2.7",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
+                "zendframework/zend-validator": "^2.10.1"
+            },
+            "suggest": {
+                "psr/http-message": "PSR-7 ^1.0.1, if you wish to use Zend\\Feed\\Reader\\Http\\Psr7ResponseDecorator",
+                "zendframework/zend-cache": "Zend\\Cache component, for optionally caching feeds between requests",
+                "zendframework/zend-db": "Zend\\Db component, for use with PubSubHubbub",
+                "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\\Reader",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for easily extending ExtensionManager implementations",
+                "zendframework/zend-validator": "Zend\\Validator component, for validating email addresses used in Atom feeds and entries when using the Writer subcomponent"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev",
+                    "dev-develop": "2.11.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Feed\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides functionality for consuming RSS and Atom feeds",
+            "keywords": [
+                "ZendFramework",
+                "feed",
+                "zf"
+            ],
+            "time": "2018-06-05T13:16:04+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "cd164b4a18b5d1aeb69be2c26db035b5ed6925ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/cd164b4a18b5d1aeb69be2c26db035b5ed6925ae",
+                "reference": "cd164b4a18b5d1aeb69be2c26db035b5ed6925ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "keywords": [
+                "ZendFramework",
+                "stdlib",
+                "zf"
+            ],
+            "time": "2018-04-30T13:50:40+00:00"
         }
     ],
     "aliases": [],

--- a/src/data.php
+++ b/src/data.php
@@ -51,6 +51,11 @@ function components(Client $client, CacheItemPoolInterface $markdownCache): arra
                 'url' => $release['html_url'],
                 'component' => $component['title'],
                 'repository' => $component['repository'],
+                'author' => [
+                    'name' => $release['author']['login'],
+                    'uri' => $release['author']['html_url'],
+                    'avatar' => $release['author']['avatar_url'],
+                ]
             ];
         }
 

--- a/theme/changelog.html.twig
+++ b/theme/changelog.html.twig
@@ -1,5 +1,9 @@
 {% extends 'default.html.twig' %}
 
+{% block head %}
+<link href="{{ base_url }}/changelog.atom" type="application/atom+xml" rel="alternate" title="Changelog">
+{% endblock %}
+
 {% block content %}
 
     <div class="container">

--- a/theme/component-changelog.html.twig
+++ b/theme/component-changelog.html.twig
@@ -1,6 +1,11 @@
 {% extends 'component.html.twig' %}
 
 {% block title %}{{ component.title ~ ': Changelog' }}{% endblock %}
+
+{% block head %}
+<link href="https://github.com/{{ component.repository }}/releases.atom" type="application/atom+xml" rel="alternate" title="{{ component.title }} Changelog">
+{% endblock %}
+
 {% block component_content %}
     <h1>{{ component.title }} Changelog</h1>
 


### PR DESCRIPTION
* Generates a combined changelog atom feed on build available at https://reactphp.org/changelog.atom.
* Adds `<link>` tags for combined and component feeds (component feeds link to github release feeds, eg. https://github.com/reactphp/socket/releases.atom)

Closes #31