### PR TITLE
Change IRC to Gitter

### DIFF
--- a/theme/default.html.twig
+++ b/theme/default.html.twig
@@ -65,7 +65,7 @@
                 <ul class="links">
                     <li><a href="https://github.com/reactphp"><i class="icon-github" aria-hidden="true"></i> GitHub</a></li>
                     <li><a href="https://twitter.com/reactphp"><i class="icon-twitter" aria-hidden="true"></i> Twitter</a></li>
-                    <li><a href="irc://irc.freenode.net/reactphp"><i class="icon-hash" aria-hidden="true"></i> IRC</a></li>
+                    <li><a href="https://gitter.im/reactphp/reactphp"><i class="icon-hash" aria-hidden="true"></i> Gitter</a></li>
                 </ul>
             </div>
         </footer>

--- a/theme/homepage.html.twig
+++ b/theme/homepage.html.twig
@@ -28,7 +28,7 @@
                             <ul class="links">
                                 <li><a href="https://github.com/reactphp"><i class="icon-github" aria-hidden="true"></i> GitHub</a></li>
                                 <li><a href="https://twitter.com/reactphp"><i class="icon-twitter" aria-hidden="true"></i> Twitter</a></li>
-                                <li><a href="irc://irc.freenode.net/reactphp"><i class="icon-hash" aria-hidden="true"></i> IRC</a></li>
+                                <li><a href="https://gitter.im/reactphp/reactphp"><i class="icon-hash" aria-hidden="true"></i> Gitter</a></li>
                             </ul>
                         </main>
                     </div>
@@ -263,8 +263,8 @@ $loop->run();
                         Please do not hesitate to file your question as an issue in the relevant component so others can also participate.
                     </p>
                     <p>
-                        Check out <code>#reactphp</code> on <code>irc.freenode.net</code>. You can use the <a href="http://webchat.freenode.net/?channels=%23reactphp" rel="nofollow">Webchat</a> if you don't already use an IRC client.
-                        Many of us are available in this channel, so many questions get answered in a few minutes to some hours. We also use this channel to announce all new releases and ongoing development efforts, so consider setting up an IRC client and idling in this channel for a little longer.
+                        You can find our official channel at <code><a href="https://gitter.im/reactphp/reactphp">reactphp/reactphp</a></code> on <code>Gitter.im</code>.
+                        Many of us are available in this channel, so many questions get answered in a few minutes to some hours. We also use this channel to announce all new releases and ongoing development efforts.
                     </p>
                     <p>
                         Also follow <a href="https://twitter.com/reactphp" rel="nofollow">@reactphp</a> on Twitter for updates. We use this mostly for noteworthy, bigger updates and to keep the community updated about ongoing development efforts.


### PR DESCRIPTION
As decided updating the website to link to our Gitter channel as our new support channel.

Closes: https://github.com/reactphp/reactphp/issues/429

@jsor I'm unsure how to change the IRC icon to the Gitter icon :zipper_mouth_face: 