### PR TITLE
Simplify usage by updating to new default loop

### DIFF
--- a/theme/homepage.html.twig
+++ b/theme/homepage.html.twig
@@ -41,9 +41,7 @@
                 <div class="welcome__example">
             {% markdown %}
 ```php
-$loop = React\EventLoop\Factory::create();
-
-$server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestInterface $request) {
+$server = new React\Http\Server(function (Psr\Http\Message\ServerRequestInterface $request) {
     return new React\Http\Message\Response(
         200,
         array(
@@ -53,15 +51,13 @@ $server = new React\Http\Server($loop, function (Psr\Http\Message\ServerRequestI
     );
 });
 
-$socket = new React\Socket\Server(8080, $loop);
+$socket = new React\Socket\Server('127.0.0.1:8080');
 $server->listen($socket);
 
-echo "Server running at http://127.0.0.1:8080\n";
-
-$loop->run();
+echo "Server running at http://127.0.0.1:8080" . PHP_EOL;
 ```
             {% endmarkdown %}
-                    <p class="center">This simple web server written in ReactPHP responds with "Hello World" for every request.</p>
+                    <p class="center">This simple web server written in ReactPHP responds with "Hello World!" for every request.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This changeset simplifies usage by updating to use the new [default loop](https://github.com/reactphp/event-loop#loop).

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/232, https://github.com/reactphp/socket/pull/260 and https://github.com/reactphp/http/pull/410