### PR TITLE
Move HttpClient and SocketClient to separate legacy section

### DIFF
--- a/data/components.php
+++ b/data/components.php
@@ -29,17 +29,12 @@ return [
     [
         'title' => 'HTTP',
         'repository' => 'reactphp/http',
-        'category' => 'Protocol Components'
-    ],
-    [
-        'title' => 'HTTPClient',
-        'repository' => 'reactphp/http-client',
-        'category' => 'Protocol Components'
+        'category' => 'Network Components'
     ],
     [
         'title' => 'DNS',
         'repository' => 'reactphp/dns',
-        'category' => 'Protocol Components'
+        'category' => 'Network Components'
     ],
     [
         'title' => 'Cache',
@@ -60,5 +55,15 @@ return [
         'title' => 'PromiseStream',
         'repository' => 'reactphp/promise-stream',
         'category' => 'Utility Components'
+    ],
+    [
+        'title' => 'HttpClient',
+        'repository' => 'reactphp/http-client',
+        'category' => 'Legacy Components'
+    ],
+    [
+        'title' => 'SocketClient',
+        'repository' => 'reactphp/socket-client',
+        'category' => 'Legacy Components'
     ],
 ];


### PR DESCRIPTION
This changeset rearranges the component sections and moves the legacy HttpClient and legacy SocketClient to a separate legacy components section. Additionally, I've merged the network and protocol components into a single section to clean up the component overview. 

I consider this to be reasonable first step to put less emphasis on our legacy components. In a follow-up PR we should eventually remove these components from the website (but special care should be taken to still include old releases in the changelog and set up appropriate redirects for existing links).


Old:
![Screenshot 2021-08-07 at 12-26-59 ReactPHP Event-driven, non-blocking I O with PHP - ReactPHP](https://user-images.githubusercontent.com/776829/128597497-8ac68c50-1b4e-473d-b936-e077eca6da3e.png)
![Screenshot 2021-08-07 at 12-28-00 ReactPHP Event-driven, non-blocking I O with PHP - ReactPHP](https://user-images.githubusercontent.com/776829/128597496-d26ea35e-7b80-4ea6-9f97-a0b27b977e66.png)

New:
![Screenshot 2021-08-07 at 12-40-04 ReactPHP Event-driven, non-blocking I O with PHP - ReactPHP](https://user-images.githubusercontent.com/776829/128597494-0ca544e0-6a85-4460-ad96-aa3f6045d863.png)
![Screenshot 2021-08-07 at 12-39-37 ReactPHP Event-driven, non-blocking I O with PHP - ReactPHP](https://user-images.githubusercontent.com/776829/128597495-f685abd9-da64-4a39-b473-3e38a5bf6ac1.png)

Refs https://github.com/reactphp/http-client/issues/152 and https://github.com/reactphp-legacy/socket-client/pull/95