### PR TITLE
Fix GitHub clone URL to avoid unencrypted Git protocol

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -59,7 +59,7 @@ if (!$input->hasParameterOption('--no-component-update')) {
             $output,
             $componentsDir,
             $component['name'],
-            $component['git_url'],
+            $component['clone_url'],
             $component['releases'][0]['tag']
         );
 


### PR DESCRIPTION
This simple changeset updates the build script to use the `clone_url` (HTTPS) instead of the `git_url` (legacy unencrypted Git protocol). This is required because GitHub no longer allows unencrypted Git access as per https://github.blog/2021-09-01-improving-git-protocol-security-github/ and the website build currently fails.

Both URLs are fetched from the GitHub API, e.g. https://api.github.com/repos/reactphp/event-loop:
![Screenshot 2022-03-17 at 15-16-41 https __api github com](https://user-images.githubusercontent.com/776829/158857138-7862d345-0a9e-480c-82ce-a48c2b4a559b.png)

