### PR TITLE
Update to use `PAT` to avoid rate limits and update build environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   Deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 7.1
       - run: composer install
       - run: mkdir ~/.ssh && echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa && chmod 400 ~/.ssh/id_rsa
-      - run: echo 'GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"' > .env && cat .env.dist >> .env
+      - run: echo 'GITHUB_TOKEN="${{ secrets.PAT || secrets.GITHUB_TOKEN }}"' > .env && cat .env.dist >> .env
       - run: git config --global user.name "GitHub Actions" && git config --global user.email "actions@github.com"
       - run: bin/build
       - run: bin/build --deploy --no-component-update

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Website
 
 [![CI status](https://github.com/reactphp/website/actions/workflows/ci.yml/badge.svg)](https://github.com/reactphp/website/actions)
-![Last deployed](https://img.shields.io/github/last-commit/reactphp/reactphp.github.io?label=last%20deployed&logo=github)
+[![Last deployed](https://img.shields.io/github/last-commit/reactphp/reactphp.github.io?label=last%20deployed&logo=github)](https://github.com/reactphp/reactphp.github.io)
 
 Source code of reactphp.org.
 
@@ -79,6 +79,10 @@ deployment script (see previous chapter).
 > Make sure the required `DEPLOY_KEY` secret is set in the repository settings on GitHub.
 > See [action documentation](https://github.com/JamesIves/github-pages-deploy-action#using-an-ssh-deploy-key-)
 > for more details.
+> On top of this, you're recommended to add a [personal access token](https://github.com/settings/tokens)
+> as a repository secret with the name `PAT` to avoid running into secondary rate limits.
+> If this secret is not found, it will fall back to the automatic `GITHUB_TOKEN`
+> secret, which may cause the build to fail occasionally.
 
 ## License
 


### PR DESCRIPTION
This changeset updates the build script to use a `PAT` secret to avoid secondary rate limits and updates the build environment. Each PAT has a rate limit of 5000 requests/h while the `GITHUB_TOKEN` has a rate limit of 1000 requests/h (https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions).

I've already assigned a read-only `PAT` for the @reactphp-bot user for this repository. This secret should be available to the build script after this PR is merged. This means that the PR may currently fail to build, but should work regardless once merged. I've assigned the same PAT to my fork to confirm this works as expected. Once merged, the build should now work again and finally deploy all releases published since #67 was reported.

Resolves / closes #67
Builds on top of #53 and #65